### PR TITLE
Use rpop to send messages from queue

### DIFF
--- a/lib/redis_to_telegram/message.rb
+++ b/lib/redis_to_telegram/message.rb
@@ -13,7 +13,7 @@ module RedisToTelegram
 
     # @param redis [Redis] from which fetch data
     def fetch(redis)
-      data = redis.lpop('sinatra_commands')
+      data = redis.rpop('sinatra_commands')
       return self if data.nil?
       parsed = JSON.parse(data)
       @text = parsed['notification']


### PR DESCRIPTION
Queue use `lpush` to send messages.
So according FIFO we should use `rpop`